### PR TITLE
skip utf-8 bom.

### DIFF
--- a/src/yuescript/yuescript.h
+++ b/src/yuescript/yuescript.h
@@ -40,6 +40,7 @@ yue.read_file = function(fname)
 	end
 	local text = assert(file:read("*a"))
 	file:close()
+	if string.sub(text, 1, 3) == "\239\187\191" then text = string.sub(text, 4) end
 	return text
 end
 local function get_options(...)


### PR DESCRIPTION
lua skips bom in lua files. It will be nice if yue skips bom too.