### PR TITLE
Improve number literal support

### DIFF
--- a/src/yuescript/yue_parser.cpp
+++ b/src/yuescript/yue_parser.cpp
@@ -50,13 +50,23 @@ YueParser::YueParser() {
 	EmptyLine = SpaceBreak;
 	AlphaNum = range('a', 'z') | range('A', 'Z') | range('0', '9') | '_';
 	Name = (range('a', 'z') | range('A', 'Z') | '_') >> *AlphaNum;
-	num_expo = set("eE") >> -expr('-') >> num_char;
+	num_expo = set("eE") >> -set("+-") >> num_char;
+	num_expo_hex = set("pP") >> -set("+-") >> num_char;
 	lj_num = -set("uU") >> set("lL") >> set("lL");
 	num_char = range('0', '9') >> *(range('0', '9') | expr('_') >> and_(range('0', '9')));
 	num_char_hex = range('0', '9') | range('a', 'f') | range('A', 'F');
 	num_lit = num_char_hex >> *(num_char_hex | expr('_') >> and_(num_char_hex));
 	Num = (
-		"0x" >> +num_lit >> -lj_num
+		"0x." >> +num_lit >> -num_expo_hex
+	) | (
+		"0x" >> +num_lit >> (
+			'.' >> +num_lit >> -num_expo_hex |
+			num_expo_hex |
+			lj_num |
+			true_()
+		)
+	) | (
+		'.' >> +num_char >> -num_expo
 	) | (
 		+num_char >> (
 			'.' >> +num_char >> -num_expo |
@@ -64,8 +74,6 @@ YueParser::YueParser() {
 			lj_num |
 			true_()
 		)
-	) | (
-		'.' >> +num_char >> -num_expo
 	);
 
 	Cut = false_();

--- a/src/yuescript/yue_parser.h
+++ b/src/yuescript/yue_parser.h
@@ -123,6 +123,7 @@ private:
 	rule num_char_hex;
 	rule num_lit;
 	rule num_expo;
+	rule num_expo_hex;
 	rule lj_num;
 	rule plain_space;
 	rule Break;


### PR DESCRIPTION
This commit improves the number literal support in the Yuescript parser to support hexadecimal point values, positive decimal exponents, and hexadecimal exponents for complete parity with the Lua and LuaJIT parsers.