### PR TITLE
Fixed undeclared specifier in yue_compiler.cpp

### DIFF
--- a/src/yuescript/yue_compiler.cpp
+++ b/src/yuescript/yue_compiler.cpp
@@ -9033,7 +9033,7 @@ private:
 			}
 #else // YUE_NO_MACRO
 			if (importAllMacro) {
-				throw CompileError("macro feature not supported"sv, import->target);
+				throw CompileError("macro feature not supported"sv, importNode->target);
 			}
 #endif // YUE_NO_MACRO
 			if (newTab->items.empty()) {


### PR DESCRIPTION
When Yuescript is compiled with `YUE_NO_MACRO` then it fails with error `C2065 'import' undeclared specifier` in Visual Studio.

This is because variable `import` was changed to `importNode` in commit 9dedf0f, but not in this one place.