### PR TITLE
Code Cleanup and Bump Dependencies

### DIFF
--- a/doc/docs/.vitepress/config.mts
+++ b/doc/docs/.vitepress/config.mts
@@ -537,6 +537,7 @@ export default defineConfig({
   var s = document.createElement('script');
   s.src = '${withBase("/js/yuescript.js")}';
   s.async = true;
+  s.onerror = loadStub;
   document.head.appendChild(s);
 })();`,
     ],

--- a/doc/docs/.vitepress/theme/components/CompilerModal.vue
+++ b/doc/docs/.vitepress/theme/components/CompilerModal.vue
@@ -60,7 +60,7 @@ export default {
   width: min(90vw, 1100px);
   max-height: 90vh;
   overflow: auto;
-  background: #ffffff;
+  background: var(--vp-c-bg);
   box-shadow: 0 20px 40px rgba(0, 0, 0, 0.2);
 }
 </style>

--- a/doc/docs/.vitepress/theme/components/YueCompiler.vue
+++ b/doc/docs/.vitepress/theme/components/YueCompiler.vue
@@ -41,165 +41,96 @@ import { history, indentWithTab } from "@codemirror/commands";
 import { defaultKeymap, historyKeymap } from "@codemirror/commands";
 import { simpleMode } from "@codemirror/legacy-modes/mode/simple-mode";
 
-/* shikijs/themes/light-plus: editor.background #FFFFFF, editor.foreground #000000 */
-const lightPlusTheme = EditorView.theme(
-  {
-    "&": {
-      height: "100%",
-      backgroundColor: "#FFFFFF",
-      color: "#000000",
-      fontSize: "14px",
+function createEditorTheme({ bg, fg, gutterColor, selectionBg, cursorColor, matchingBracketBg, dark }) {
+  return EditorView.theme(
+    {
+      "&": {
+        height: "100%",
+        backgroundColor: bg,
+        color: fg,
+        fontSize: "14px",
+      },
+      "&.cm-focused": { outline: "none" },
+      ".cm-content": {
+        fontFamily:
+          "ui-monospace, 'Menlo', 'Monaco', 'Consolas', 'Liberation Mono', 'Courier New', monospace",
+        lineHeight: "1.375",
+      },
+      ".cm-gutters": {
+        backgroundColor: bg,
+        color: gutterColor,
+        borderRight: "none",
+      },
+      ".cm-activeLine": { backgroundColor: "transparent" },
+      ".cm-activeLineGutter": { backgroundColor: "transparent" },
+      ".cm-selectionBackground": { backgroundColor: selectionBg },
+      "&.cm-focused .cm-selectionBackground": { backgroundColor: selectionBg },
+      ".cm-cursor": { borderLeftColor: cursorColor },
+      ".cm-matchingBracket": { backgroundColor: matchingBracketBg },
     },
-    "&.cm-focused": {
-      outline: "none",
-    },
-    ".cm-content": {
-      fontFamily:
-        "ui-monospace, 'Menlo', 'Monaco', 'Consolas', 'Liberation Mono', 'Courier New', monospace",
-      lineHeight: "1.375",
-    },
-    ".cm-gutters": {
-      backgroundColor: "#FFFFFF",
-      color: "#6e6e6e",
-      borderRight: "none",
-    },
-    ".cm-activeLine": {
-      backgroundColor: "transparent",
-    },
-    ".cm-activeLineGutter": {
-      backgroundColor: "transparent",
-    },
-    ".cm-selectionBackground": {
-      backgroundColor: "#add6ff",
-    },
-    "&.cm-focused .cm-selectionBackground": {
-      backgroundColor: "#add6ff",
-    },
-    ".cm-cursor": {
-      borderLeftColor: "#000000",
-    },
-    ".cm-matchingBracket": {
-      backgroundColor: "#c9def5",
-    },
-  },
-  { dark: false },
-);
+    { dark },
+  );
+}
 
-/* shikijs/themes/dark-plus: editor.background #1E1E1E, editor.foreground #D4D4D4 */
-const darkPlusTheme = EditorView.theme(
-  {
-    "&": {
-      height: "100%",
-      backgroundColor: "#1E1E1E",
-      color: "#D4D4D4",
-      fontSize: "14px",
-    },
-    "&.cm-focused": {
-      outline: "none",
-    },
-    ".cm-content": {
-      fontFamily:
-        "ui-monospace, 'Menlo', 'Monaco', 'Consolas', 'Liberation Mono', 'Courier New', monospace",
-      lineHeight: "1.375",
-    },
-    ".cm-gutters": {
-      backgroundColor: "#1E1E1E",
-      color: "#858585",
-      borderRight: "none",
-    },
-    ".cm-activeLine": {
-      backgroundColor: "transparent",
-    },
-    ".cm-activeLineGutter": {
-      backgroundColor: "transparent",
-    },
-    ".cm-selectionBackground": {
-      backgroundColor: "#264f78",
-    },
-    "&.cm-focused .cm-selectionBackground": {
-      backgroundColor: "#264f78",
-    },
-    ".cm-cursor": {
-      borderLeftColor: "#aeafad",
-    },
-    ".cm-matchingBracket": {
-      backgroundColor: "#3a3d41",
-    },
-  },
-  { dark: true },
-);
+const lightPlusTheme = createEditorTheme({
+  bg: "#FFFFFF", fg: "#000000", gutterColor: "#6e6e6e",
+  selectionBg: "#add6ff", cursorColor: "#000000", matchingBracketBg: "#c9def5", dark: false,
+});
 
-/* shikijs/themes/light-plus tokenColors */
-const lightPlusHighlightStyle = HighlightStyle.define(
-  [
-    { tag: tags.comment, color: "#008000" },
-    { tag: tags.keyword, color: "#AF00DB" },
-    { tag: [tags.operator, tags.punctuation], color: "#000000" },
-    { tag: [tags.string, tags.special(tags.string)], color: "#a31515" },
-    { tag: tags.regexp, color: "#811f3f" },
-    { tag: [tags.number, tags.bool, tags.null], color: "#098658" },
-    { tag: tags.function(tags.variableName), color: "#795e26" },
-    { tag: tags.typeName, color: "#267f99" },
-    { tag: tags.className, color: "#267f99" },
-    { tag: tags.propertyName, color: "#001080" },
-    { tag: tags.tagName, color: "#800000" },
-    { tag: tags.attributeName, color: "#e50000" },
-    { tag: tags.meta, color: "#666666" },
-    { tag: tags.invalid, color: "#cd3131" },
-    // Additional tags for YueScript - ensure all token types have styles
-    { tag: tags.variableName, color: "#001080" },
-    { tag: tags.constant(tags.name), color: "#098658" },
-    { tag: tags.constant(tags.variableName), color: "#098658" },
-    { tag: tags.constant, color: "#098658" },
-    { tag: tags.definition(tags.variableName), color: "#001080" },
-    { tag: tags.modifier, color: "#AF00DB" },
-    { tag: tags.namespace, color: "#267f99" },
-    { tag: tags.labelName, color: "#795e26" },
-    { tag: tags.character, color: "#098658" },
-    { tag: tags.literal, color: "#098658" },
-    { tag: tags.bracket, color: "#000000" },
-    { tag: tags.squareBracket, color: "#000000" },
-    { tag: tags.paren, color: "#000000" },
-    { tag: tags.brace, color: "#000000" },
-  ],
-  { fallback: true },
-);
+const darkPlusTheme = createEditorTheme({
+  bg: "#1E1E1E", fg: "#D4D4D4", gutterColor: "#858585",
+  selectionBg: "#264f78", cursorColor: "#aeafad", matchingBracketBg: "#3a3d41", dark: true,
+});
 
-/* shikijs/themes/dark-plus tokenColors */
-const darkPlusHighlightStyle = HighlightStyle.define(
-  [
-    { tag: tags.comment, color: "#6a9955" },
-    { tag: tags.keyword, color: "#C586C0" },
-    { tag: [tags.operator, tags.punctuation], color: "#d4d4d4" },
-    { tag: [tags.string, tags.special(tags.string)], color: "#ce9178" },
-    { tag: tags.regexp, color: "#d16969" },
-    { tag: [tags.number, tags.bool, tags.null], color: "#b5cea8" },
-    { tag: tags.function(tags.variableName), color: "#dcdcaa" },
-    { tag: tags.typeName, color: "#4ec9b0" },
-    { tag: tags.className, color: "#4ec9b0" },
-    { tag: tags.propertyName, color: "#9cdcfe" },
-    { tag: tags.tagName, color: "#569cd6" },
-    { tag: tags.attributeName, color: "#9cdcfe" },
-    { tag: tags.meta, color: "#d4d4d4" },
-    { tag: tags.invalid, color: "#f44747" },
-    // Additional tags for YueScript - ensure all token types have styles
-    { tag: tags.variableName, color: "#9cdcfe" },
-    { tag: tags.constant(tags.name), color: "#b5cea8" },
-    { tag: tags.constant(tags.variableName), color: "#b5cea8" },
-    { tag: tags.constant, color: "#b5cea8" },
-    { tag: tags.definition(tags.variableName), color: "#9cdcfe" },
-    { tag: tags.modifier, color: "#C586C0" },
-    { tag: tags.namespace, color: "#4ec9b0" },
-    { tag: tags.labelName, color: "#dcdcaa" },
-    { tag: tags.character, color: "#b5cea8" },
-    { tag: tags.literal, color: "#b5cea8" },
-    { tag: tags.bracket, color: "#d4d4d4" },
-    { tag: tags.squareBracket, color: "#d4d4d4" },
-    { tag: tags.paren, color: "#d4d4d4" },
-    { tag: tags.brace, color: "#d4d4d4" },
-  ],
-  { fallback: true },
-);
+function createHighlightStyle(c) {
+  return HighlightStyle.define(
+    [
+      { tag: tags.comment, color: c.comment },
+      { tag: tags.keyword, color: c.keyword },
+      { tag: [tags.operator, tags.punctuation], color: c.punctuation },
+      { tag: [tags.string, tags.special(tags.string)], color: c.string },
+      { tag: tags.regexp, color: c.regexp },
+      { tag: [tags.number, tags.bool, tags.null], color: c.number },
+      { tag: tags.function(tags.variableName), color: c.function },
+      { tag: tags.typeName, color: c.type },
+      { tag: tags.className, color: c.type },
+      { tag: tags.propertyName, color: c.property },
+      { tag: tags.tagName, color: c.tag },
+      { tag: tags.attributeName, color: c.attribute },
+      { tag: tags.meta, color: c.meta },
+      { tag: tags.invalid, color: c.invalid },
+      { tag: tags.variableName, color: c.property },
+      { tag: tags.constant(tags.name), color: c.number },
+      { tag: tags.constant(tags.variableName), color: c.number },
+      { tag: tags.constant, color: c.number },
+      { tag: tags.definition(tags.variableName), color: c.property },
+      { tag: tags.modifier, color: c.keyword },
+      { tag: tags.namespace, color: c.type },
+      { tag: tags.labelName, color: c.function },
+      { tag: tags.character, color: c.number },
+      { tag: tags.literal, color: c.number },
+      { tag: tags.bracket, color: c.punctuation },
+      { tag: tags.squareBracket, color: c.punctuation },
+      { tag: tags.paren, color: c.punctuation },
+      { tag: tags.brace, color: c.punctuation },
+    ],
+    { fallback: true },
+  );
+}
+
+const lightPlusHighlightStyle = createHighlightStyle({
+  comment: "#008000", keyword: "#AF00DB", punctuation: "#000000",
+  string: "#a31515", regexp: "#811f3f", number: "#098658",
+  function: "#795e26", type: "#267f99", property: "#001080",
+  tag: "#800000", attribute: "#e50000", meta: "#666666", invalid: "#cd3131",
+});
+
+const darkPlusHighlightStyle = createHighlightStyle({
+  comment: "#6a9955", keyword: "#C586C0", punctuation: "#d4d4d4",
+  string: "#ce9178", regexp: "#d16969", number: "#b5cea8",
+  function: "#dcdcaa", type: "#4ec9b0", property: "#9cdcfe",
+  tag: "#569cd6", attribute: "#9cdcfe", meta: "#d4d4d4", invalid: "#f44747",
+});
 
 export default {
   props: {
@@ -229,6 +160,7 @@ export default {
       themeCompartment: null,
       highlightCompartment: null,
       themeObserver: null,
+      _onYueReady: null,
     };
   },
   computed: {
@@ -244,7 +176,7 @@ export default {
     window.addEventListener("resize", this.handleResize);
     this.observeTheme();
 
-    const initialCode = this.text !== "" ? this.text : "";
+    const initialCode = this.text;
     this.code = initialCode;
     this.codeChanged(initialCode);
     this.initEditor(initialCode);
@@ -252,21 +184,26 @@ export default {
       this.focusEditorToEnd();
     });
 
-    const check = ((self) => {
-      return () => {
-        if (window.yue) {
-          self.info = window.yue.version();
-          self.readonly = false;
-          this.refreshEditorReadOnly();
-        } else {
-          setTimeout(check, 100);
-        }
-      };
-    })(this);
-    check();
+    const onYueReady = () => {
+      if (window.yue) {
+        this.info = window.yue.version();
+        this.readonly = false;
+        this.refreshEditorReadOnly();
+      }
+    };
+    if (window.yue) {
+      onYueReady();
+    } else {
+      this._onYueReady = onYueReady;
+      window.addEventListener("yue:ready", onYueReady, { once: true });
+    }
   },
   beforeUnmount() {
     window.removeEventListener("resize", this.handleResize);
+    if (this._onYueReady) {
+      window.removeEventListener("yue:ready", this._onYueReady);
+      this._onYueReady = null;
+    }
     if (this.editorView) {
       this.editorView.destroy();
       this.editorView = null;
@@ -673,7 +610,7 @@ export default {
   overflow-wrap: break-word;
   width: calc(100% - 120px);
   height: 55px;
-  border-color: #b7ae8f;
+  border-color: var(--vp-button-brand-bg);
   border-radius: 4px;
   border-width: 1px;
   border-style: solid;
@@ -722,20 +659,20 @@ export default {
   border: none;
   display: inline-block;
   font-size: 1.2rem;
-  color: #fff;
-  background-color: #b7ae8f;
+  color: var(--vp-button-brand-text);
+  background-color: var(--vp-button-brand-bg);
   text-decoration: none;
   padding: 0.8rem 1.6rem;
   border-radius: 4px;
   transition: background-color 0.1s ease;
   box-sizing: border-box;
-  border-bottom: 1px solid #aaa07b;
+  border-bottom: 1px solid var(--vp-button-brand-border);
   margin-top: 10px;
   margin-right: 5px;
 }
 
 .button:hover {
-  background-color: #beb69a;
+  background-color: var(--vp-button-brand-hover-bg);
 }
 
 .button:focus,

--- a/doc/docs/.vitepress/theme/components/YueDisplay.vue
+++ b/doc/docs/.vitepress/theme/components/YueDisplay.vue
@@ -28,18 +28,18 @@ export default {
   border: none;
   display: inline-block;
   font-size: 16px;
-  color: #fff;
-  background-color: #b7ae8f;
+  color: var(--vp-button-brand-text);
+  background-color: var(--vp-button-brand-bg);
   text-decoration: none;
   padding: 0.4rem 0.8rem;
   border-radius: 4px;
   transition: background-color 0.1s ease;
   box-sizing: border-box;
-  border-bottom: 1px solid #aaa07b;
+  border-bottom: 1px solid var(--vp-button-brand-border);
   margin-bottom: 1em;
 }
 .button:hover {
-  background-color: #beb69a;
+  background-color: var(--vp-button-brand-hover-bg);
 }
 .button:focus,
 .button:active:focus,

--- a/doc/package.json
+++ b/doc/package.json
@@ -15,20 +15,20 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@types/node": "^25.2.3",
+    "@types/node": "^25.5.0",
     "vitepress": "^1.6.4",
-    "vue": "^3.5.28"
+    "vue": "^3.5.31"
   },
   "dependencies": {
-    "@codemirror/commands": "^6.10.1",
-    "@codemirror/language": "^6.12.1",
+    "@codemirror/commands": "^6.10.3",
+    "@codemirror/language": "^6.12.3",
     "@codemirror/legacy-modes": "^6.5.2",
-    "@codemirror/state": "^6.5.4",
-    "@codemirror/view": "^6.39.12",
+    "@codemirror/state": "^6.6.0",
+    "@codemirror/view": "^6.40.0",
     "@fontsource/merriweather": "^5.2.11",
     "@fontsource/noto-serif-sc": "^5.2.8",
     "@lezer/highlight": "^1.2.3",
-    "@shikijs/themes": "^3.22.0",
-    "prismjs": "^1.29.0"
+    "@shikijs/themes": "^4.0.2",
+    "prismjs": "^1.30.0"
   }
 }

--- a/doc/pnpm-lock.yaml
+++ b/doc/pnpm-lock.yaml
@@ -9,20 +9,20 @@ importers:
   .:
     dependencies:
       '@codemirror/commands':
-        specifier: ^6.10.1
-        version: 6.10.2
+        specifier: ^6.10.3
+        version: 6.10.3
       '@codemirror/language':
-        specifier: ^6.12.1
-        version: 6.12.1
+        specifier: ^6.12.3
+        version: 6.12.3
       '@codemirror/legacy-modes':
         specifier: ^6.5.2
         version: 6.5.2
       '@codemirror/state':
-        specifier: ^6.5.4
-        version: 6.5.4
+        specifier: ^6.6.0
+        version: 6.6.0
       '@codemirror/view':
-        specifier: ^6.39.12
-        version: 6.39.15
+        specifier: ^6.40.0
+        version: 6.40.0
       '@fontsource/merriweather':
         specifier: ^5.2.11
         version: 5.2.11
@@ -33,21 +33,21 @@ importers:
         specifier: ^1.2.3
         version: 1.2.3
       '@shikijs/themes':
-        specifier: ^3.22.0
-        version: 3.22.0
+        specifier: ^4.0.2
+        version: 4.0.2
       prismjs:
-        specifier: ^1.29.0
+        specifier: ^1.30.0
         version: 1.30.0
     devDependencies:
       '@types/node':
-        specifier: ^25.2.3
-        version: 25.3.0
+        specifier: ^25.5.0
+        version: 25.5.0
       vitepress:
         specifier: ^1.6.4
-        version: 1.6.4(@algolia/client-search@5.49.1)(@types/node@25.3.0)(postcss@8.5.6)(search-insights@2.17.3)
+        version: 1.6.4(@algolia/client-search@5.49.1)(@types/node@25.5.0)(postcss@8.5.8)(search-insights@2.17.3)
       vue:
-        specifier: ^3.5.28
-        version: 3.5.29
+        specifier: ^3.5.31
+        version: 3.5.31
 
 packages:
 
@@ -135,8 +135,8 @@ packages:
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/parser@7.29.0':
-    resolution: {integrity: sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==}
+  '@babel/parser@7.29.2':
+    resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -144,20 +144,20 @@ packages:
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
-  '@codemirror/commands@6.10.2':
-    resolution: {integrity: sha512-vvX1fsih9HledO1c9zdotZYUZnE4xV0m6i3m25s5DIfXofuprk6cRcLUZvSk3CASUbwjQX21tOGbkY2BH8TpnQ==}
+  '@codemirror/commands@6.10.3':
+    resolution: {integrity: sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q==}
 
-  '@codemirror/language@6.12.1':
-    resolution: {integrity: sha512-Fa6xkSiuGKc8XC8Cn96T+TQHYj4ZZ7RdFmXA3i9xe/3hLHfwPZdM+dqfX0Cp0zQklBKhVD8Yzc8LS45rkqcwpQ==}
+  '@codemirror/language@6.12.3':
+    resolution: {integrity: sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==}
 
   '@codemirror/legacy-modes@6.5.2':
     resolution: {integrity: sha512-/jJbwSTazlQEDOQw2FJ8LEEKVS72pU0lx6oM54kGpL8t/NJ2Jda3CZ4pcltiKTdqYSRk3ug1B3pil1gsjA6+8Q==}
 
-  '@codemirror/state@6.5.4':
-    resolution: {integrity: sha512-8y7xqG/hpB53l25CIoit9/ngxdfoG+fx+V3SHBrinnhOtLvKHRyAJJuHzkWrR4YXXLX8eXBsejgAAxHUOdW1yw==}
+  '@codemirror/state@6.6.0':
+    resolution: {integrity: sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==}
 
-  '@codemirror/view@6.39.15':
-    resolution: {integrity: sha512-aCWjgweIIXLBHh7bY6cACvXuyrZ0xGafjQ2VInjp4RM4gMfscK5uESiNdrH0pE+e1lZr2B4ONGsjchl2KsKZzg==}
+  '@codemirror/view@6.40.0':
+    resolution: {integrity: sha512-WA0zdU7xfF10+5I3HhUUq3kqOx3KjqmtQ9lqZjfK7jtYk4G72YW9rezcSywpaUMCWOMlq+6E0pO1IWg1TNIhtg==}
 
   '@docsearch/css@3.8.2':
     resolution: {integrity: sha512-y05ayQFyUmCXze79+56v/4HpycYF3uFqB78pLPrSV5ZKAlDuIAAJNhaRi8tTdRNXh05yxX/TyNnzD6LwSM89vQ==}
@@ -500,8 +500,9 @@ packages:
   '@shikijs/themes@2.5.0':
     resolution: {integrity: sha512-wGrk+R8tJnO0VMzmUExHR+QdSaPUl/NKs+a4cQQRWyoc3YFbUzuLEi/KWK1hj+8BfHRKm2jNhhJck1dfstJpiw==}
 
-  '@shikijs/themes@3.22.0':
-    resolution: {integrity: sha512-o+tlOKqsr6FE4+mYJG08tfCFDS+3CG20HbldXeVoyP+cYSUxDhrFf3GPjE60U55iOkkjbpY2uC3It/eeja35/g==}
+  '@shikijs/themes@4.0.2':
+    resolution: {integrity: sha512-mjCafwt8lJJaVSsQvNVrJumbnnj1RI8jbUKrPKgE6E3OvQKxnuRoBaYC51H4IGHePsGN/QtALglWBU7DoKDFnA==}
+    engines: {node: '>=20'}
 
   '@shikijs/transformers@2.5.0':
     resolution: {integrity: sha512-SI494W5X60CaUwgi8u4q4m4s3YAFSxln3tzNjOSYqq54wlVgz0/NbbXEb3mdLbqMBztcmS7bVTaEd2w0qMmfeg==}
@@ -509,8 +510,9 @@ packages:
   '@shikijs/types@2.5.0':
     resolution: {integrity: sha512-ygl5yhxki9ZLNuNpPitBWvcy9fsSKKaRuO4BAlMyagszQidxcpLAr0qiW/q43DtSIDxO6hEbtYLiFZNXO/hdGw==}
 
-  '@shikijs/types@3.22.0':
-    resolution: {integrity: sha512-491iAekgKDBFE67z70Ok5a8KBMsQ2IJwOWw3us/7ffQkIBCyOQfm/aNwVMBUriP02QshIfgHCBSIYAl3u2eWjg==}
+  '@shikijs/types@4.0.2':
+    resolution: {integrity: sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg==}
+    engines: {node: '>=20'}
 
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
@@ -533,8 +535,8 @@ packages:
   '@types/mdurl@2.0.0':
     resolution: {integrity: sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==}
 
-  '@types/node@25.3.0':
-    resolution: {integrity: sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A==}
+  '@types/node@25.5.0':
+    resolution: {integrity: sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==}
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
@@ -552,17 +554,17 @@ packages:
       vite: ^5.0.0 || ^6.0.0
       vue: ^3.2.25
 
-  '@vue/compiler-core@3.5.29':
-    resolution: {integrity: sha512-cuzPhD8fwRHk8IGfmYaR4eEe4cAyJEL66Ove/WZL7yWNL134nqLddSLwNRIsFlnnW1kK+p8Ck3viFnC0chXCXw==}
+  '@vue/compiler-core@3.5.31':
+    resolution: {integrity: sha512-k/ueL14aNIEy5Onf0OVzR8kiqF/WThgLdFhxwa4e/KF/0qe38IwIdofoSWBTvvxQOesaz6riAFAUaYjoF9fLLQ==}
 
-  '@vue/compiler-dom@3.5.29':
-    resolution: {integrity: sha512-n0G5o7R3uBVmVxjTIYcz7ovr8sy7QObFG8OQJ3xGCDNhbG60biP/P5KnyY8NLd81OuT1WJflG7N4KWYHaeeaIg==}
+  '@vue/compiler-dom@3.5.31':
+    resolution: {integrity: sha512-BMY/ozS/xxjYqRFL+tKdRpATJYDTTgWSo0+AJvJNg4ig+Hgb0dOsHPXvloHQ5hmlivUqw1Yt2pPIqp4e0v1GUw==}
 
-  '@vue/compiler-sfc@3.5.29':
-    resolution: {integrity: sha512-oJZhN5XJs35Gzr50E82jg2cYdZQ78wEwvRO6Y63TvLVTc+6xICzJHP1UIecdSPPYIbkautNBanDiWYa64QSFIA==}
+  '@vue/compiler-sfc@3.5.31':
+    resolution: {integrity: sha512-M8wpPgR9UJ8MiRGjppvx9uWJfLV7A/T+/rL8s/y3QG3u0c2/YZgff3d6SuimKRIhcYnWg5fTfDMlz2E6seUW8Q==}
 
-  '@vue/compiler-ssr@3.5.29':
-    resolution: {integrity: sha512-Y/ARJZE6fpjzL5GH/phJmsFwx3g6t2KmHKHx5q+MLl2kencADKIrhH5MLF6HHpRMmlRAYBRSvv347Mepf1zVNw==}
+  '@vue/compiler-ssr@3.5.31':
+    resolution: {integrity: sha512-h0xIMxrt/LHOvJKMri+vdYT92BrK3HFLtDqq9Pr/lVVfE4IyKZKvWf0vJFW10Yr6nX02OR4MkJwI0c1HDa1hog==}
 
   '@vue/devtools-api@7.7.9':
     resolution: {integrity: sha512-kIE8wvwlcZ6TJTbNeU2HQNtaxLx3a84aotTITUuL/4bzfPxzajGBOoqjMhwZJ8L9qFYDU/lAYMEEm11dnZOD6g==}
@@ -573,22 +575,25 @@ packages:
   '@vue/devtools-shared@7.7.9':
     resolution: {integrity: sha512-iWAb0v2WYf0QWmxCGy0seZNDPdO3Sp5+u78ORnyeonS6MT4PC7VPrryX2BpMJrwlDeaZ6BD4vP4XKjK0SZqaeA==}
 
-  '@vue/reactivity@3.5.29':
-    resolution: {integrity: sha512-zcrANcrRdcLtmGZETBxWqIkoQei8HaFpZWx/GHKxx79JZsiZ8j1du0VUJtu4eJjgFvU/iKL5lRXFXksVmI+5DA==}
+  '@vue/reactivity@3.5.31':
+    resolution: {integrity: sha512-DtKXxk9E/KuVvt8VxWu+6Luc9I9ETNcqR1T1oW1gf02nXaZ1kuAx58oVu7uX9XxJR0iJCro6fqBLw9oSBELo5g==}
 
-  '@vue/runtime-core@3.5.29':
-    resolution: {integrity: sha512-8DpW2QfdwIWOLqtsNcds4s+QgwSaHSJY/SUe04LptianUQ/0xi6KVsu/pYVh+HO3NTVvVJjIPL2t6GdeKbS4Lg==}
+  '@vue/runtime-core@3.5.31':
+    resolution: {integrity: sha512-AZPmIHXEAyhpkmN7aWlqjSfYynmkWlluDNPHMCZKFHH+lLtxP/30UJmoVhXmbDoP1Ng0jG0fyY2zCj1PnSSA6Q==}
 
-  '@vue/runtime-dom@3.5.29':
-    resolution: {integrity: sha512-AHvvJEtcY9tw/uk+s/YRLSlxxQnqnAkjqvK25ZiM4CllCZWzElRAoQnCM42m9AHRLNJ6oe2kC5DCgD4AUdlvXg==}
+  '@vue/runtime-dom@3.5.31':
+    resolution: {integrity: sha512-xQJsNRmGPeDCJq/u813tyonNgWBFjzfVkBwDREdEWndBnGdHLHgkwNBQxLtg4zDrzKTEcnikUy1UUNecb3lJ6g==}
 
-  '@vue/server-renderer@3.5.29':
-    resolution: {integrity: sha512-G/1k6WK5MusLlbxSE2YTcqAAezS+VuwHhOvLx2KnQU7G2zCH6KIb+5Wyt6UjMq7a3qPzNEjJXs1hvAxDclQH+g==}
+  '@vue/server-renderer@3.5.31':
+    resolution: {integrity: sha512-GJuwRvMcdZX/CriUnyIIOGkx3rMV3H6sOu0JhdKbduaeCji6zb60iOGMY7tFoN24NfsUYoFBhshZtGxGpxO4iA==}
     peerDependencies:
-      vue: 3.5.29
+      vue: 3.5.31
 
   '@vue/shared@3.5.29':
     resolution: {integrity: sha512-w7SR0A5zyRByL9XUkCfdLs7t9XOHUyJ67qPGQjOou3p6GvBeBW+AVjUUmlxtZ4PIYaRvE+1LmK44O4uajlZwcg==}
+
+  '@vue/shared@3.5.31':
+    resolution: {integrity: sha512-nBxuiuS9Lj5bPkPbWogPUnjxxWpkRniX7e5UBQDWl6Fsf4roq9wwV+cR7ezQ4zXswNvPIlsdj1slcLB7XCsRAw==}
 
   '@vueuse/core@12.8.2':
     resolution: {integrity: sha512-HbvCmZdzAu3VGi/pWYm5Ut+Kd9mn1ZHnn4L5G8kOQTPs/IwIAmJoBrmYk2ckLArgMXZj0AW3n5CAejLUO+PhdQ==}
@@ -763,6 +768,10 @@ packages:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  postcss@8.5.8:
+    resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
+    engines: {node: ^10 || ^12 || >=14}
+
   preact@10.28.4:
     resolution: {integrity: sha512-uKFfOHWuSNpRFVTnljsCluEFq57OKT+0QdOiQo8XWnQ/pSvg7OpX5eNOejELXJMWy+BwM2nobz0FkvzmnpCNsQ==}
 
@@ -890,8 +899,8 @@ packages:
       postcss:
         optional: true
 
-  vue@3.5.29:
-    resolution: {integrity: sha512-BZqN4Ze6mDQVNAni0IHeMJ5mwr8VAJ3MQC9FmprRhcBYENw+wOAAjRj8jfmN6FLl0j96OXbR+CjWhmAmM+QGnA==}
+  vue@3.5.31:
+    resolution: {integrity: sha512-iV/sU9SzOlmA/0tygSmjkEN6Jbs3nPoIPFhCMLD2STrjgOU8DX7ZtzMhg4ahVwf5Rp9KoFzcXeB1ZrVbLBp5/Q==}
     peerDependencies:
       typescript: '*'
     peerDependenciesMeta:
@@ -1022,7 +1031,7 @@ snapshots:
 
   '@babel/helper-validator-identifier@7.28.5': {}
 
-  '@babel/parser@7.29.0':
+  '@babel/parser@7.29.2':
     dependencies:
       '@babel/types': 7.29.0
 
@@ -1031,17 +1040,17 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
-  '@codemirror/commands@6.10.2':
+  '@codemirror/commands@6.10.3':
     dependencies:
-      '@codemirror/language': 6.12.1
-      '@codemirror/state': 6.5.4
-      '@codemirror/view': 6.39.15
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.40.0
       '@lezer/common': 1.5.1
 
-  '@codemirror/language@6.12.1':
+  '@codemirror/language@6.12.3':
     dependencies:
-      '@codemirror/state': 6.5.4
-      '@codemirror/view': 6.39.15
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.40.0
       '@lezer/common': 1.5.1
       '@lezer/highlight': 1.2.3
       '@lezer/lr': 1.4.8
@@ -1049,15 +1058,15 @@ snapshots:
 
   '@codemirror/legacy-modes@6.5.2':
     dependencies:
-      '@codemirror/language': 6.12.1
+      '@codemirror/language': 6.12.3
 
-  '@codemirror/state@6.5.4':
+  '@codemirror/state@6.6.0':
     dependencies:
       '@marijn/find-cluster-break': 1.0.2
 
-  '@codemirror/view@6.39.15':
+  '@codemirror/view@6.40.0':
     dependencies:
-      '@codemirror/state': 6.5.4
+      '@codemirror/state': 6.6.0
       crelt: 1.0.6
       style-mod: 4.1.3
       w3c-keyname: 2.2.8
@@ -1282,9 +1291,9 @@ snapshots:
     dependencies:
       '@shikijs/types': 2.5.0
 
-  '@shikijs/themes@3.22.0':
+  '@shikijs/themes@4.0.2':
     dependencies:
-      '@shikijs/types': 3.22.0
+      '@shikijs/types': 4.0.2
 
   '@shikijs/transformers@2.5.0':
     dependencies:
@@ -1296,7 +1305,7 @@ snapshots:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
 
-  '@shikijs/types@3.22.0':
+  '@shikijs/types@4.0.2':
     dependencies:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
@@ -1322,7 +1331,7 @@ snapshots:
 
   '@types/mdurl@2.0.0': {}
 
-  '@types/node@25.3.0':
+  '@types/node@25.5.0':
     dependencies:
       undici-types: 7.18.2
 
@@ -1332,40 +1341,40 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vitejs/plugin-vue@5.2.4(vite@5.4.21(@types/node@25.3.0))(vue@3.5.29)':
+  '@vitejs/plugin-vue@5.2.4(vite@5.4.21(@types/node@25.5.0))(vue@3.5.31)':
     dependencies:
-      vite: 5.4.21(@types/node@25.3.0)
-      vue: 3.5.29
+      vite: 5.4.21(@types/node@25.5.0)
+      vue: 3.5.31
 
-  '@vue/compiler-core@3.5.29':
+  '@vue/compiler-core@3.5.31':
     dependencies:
-      '@babel/parser': 7.29.0
-      '@vue/shared': 3.5.29
+      '@babel/parser': 7.29.2
+      '@vue/shared': 3.5.31
       entities: 7.0.1
       estree-walker: 2.0.2
       source-map-js: 1.2.1
 
-  '@vue/compiler-dom@3.5.29':
+  '@vue/compiler-dom@3.5.31':
     dependencies:
-      '@vue/compiler-core': 3.5.29
-      '@vue/shared': 3.5.29
+      '@vue/compiler-core': 3.5.31
+      '@vue/shared': 3.5.31
 
-  '@vue/compiler-sfc@3.5.29':
+  '@vue/compiler-sfc@3.5.31':
     dependencies:
-      '@babel/parser': 7.29.0
-      '@vue/compiler-core': 3.5.29
-      '@vue/compiler-dom': 3.5.29
-      '@vue/compiler-ssr': 3.5.29
-      '@vue/shared': 3.5.29
+      '@babel/parser': 7.29.2
+      '@vue/compiler-core': 3.5.31
+      '@vue/compiler-dom': 3.5.31
+      '@vue/compiler-ssr': 3.5.31
+      '@vue/shared': 3.5.31
       estree-walker: 2.0.2
       magic-string: 0.30.21
-      postcss: 8.5.6
+      postcss: 8.5.8
       source-map-js: 1.2.1
 
-  '@vue/compiler-ssr@3.5.29':
+  '@vue/compiler-ssr@3.5.31':
     dependencies:
-      '@vue/compiler-dom': 3.5.29
-      '@vue/shared': 3.5.29
+      '@vue/compiler-dom': 3.5.31
+      '@vue/shared': 3.5.31
 
   '@vue/devtools-api@7.7.9':
     dependencies:
@@ -1385,36 +1394,38 @@ snapshots:
     dependencies:
       rfdc: 1.4.1
 
-  '@vue/reactivity@3.5.29':
+  '@vue/reactivity@3.5.31':
     dependencies:
-      '@vue/shared': 3.5.29
+      '@vue/shared': 3.5.31
 
-  '@vue/runtime-core@3.5.29':
+  '@vue/runtime-core@3.5.31':
     dependencies:
-      '@vue/reactivity': 3.5.29
-      '@vue/shared': 3.5.29
+      '@vue/reactivity': 3.5.31
+      '@vue/shared': 3.5.31
 
-  '@vue/runtime-dom@3.5.29':
+  '@vue/runtime-dom@3.5.31':
     dependencies:
-      '@vue/reactivity': 3.5.29
-      '@vue/runtime-core': 3.5.29
-      '@vue/shared': 3.5.29
+      '@vue/reactivity': 3.5.31
+      '@vue/runtime-core': 3.5.31
+      '@vue/shared': 3.5.31
       csstype: 3.2.3
 
-  '@vue/server-renderer@3.5.29(vue@3.5.29)':
+  '@vue/server-renderer@3.5.31(vue@3.5.31)':
     dependencies:
-      '@vue/compiler-ssr': 3.5.29
-      '@vue/shared': 3.5.29
-      vue: 3.5.29
+      '@vue/compiler-ssr': 3.5.31
+      '@vue/shared': 3.5.31
+      vue: 3.5.31
 
   '@vue/shared@3.5.29': {}
+
+  '@vue/shared@3.5.31': {}
 
   '@vueuse/core@12.8.2':
     dependencies:
       '@types/web-bluetooth': 0.0.21
       '@vueuse/metadata': 12.8.2
       '@vueuse/shared': 12.8.2
-      vue: 3.5.29
+      vue: 3.5.31
     transitivePeerDependencies:
       - typescript
 
@@ -1422,7 +1433,7 @@ snapshots:
     dependencies:
       '@vueuse/core': 12.8.2
       '@vueuse/shared': 12.8.2
-      vue: 3.5.29
+      vue: 3.5.31
     optionalDependencies:
       focus-trap: 7.8.0
     transitivePeerDependencies:
@@ -1432,7 +1443,7 @@ snapshots:
 
   '@vueuse/shared@12.8.2':
     dependencies:
-      vue: 3.5.29
+      vue: 3.5.31
     transitivePeerDependencies:
       - typescript
 
@@ -1597,6 +1608,12 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  postcss@8.5.8:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
   preact@10.28.4: {}
 
   prismjs@1.30.0: {}
@@ -1715,16 +1732,16 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite@5.4.21(@types/node@25.3.0):
+  vite@5.4.21(@types/node@25.5.0):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.6
       rollup: 4.59.0
     optionalDependencies:
-      '@types/node': 25.3.0
+      '@types/node': 25.5.0
       fsevents: 2.3.3
 
-  vitepress@1.6.4(@algolia/client-search@5.49.1)(@types/node@25.3.0)(postcss@8.5.6)(search-insights@2.17.3):
+  vitepress@1.6.4(@algolia/client-search@5.49.1)(@types/node@25.5.0)(postcss@8.5.8)(search-insights@2.17.3):
     dependencies:
       '@docsearch/css': 3.8.2
       '@docsearch/js': 3.8.2(@algolia/client-search@5.49.1)(search-insights@2.17.3)
@@ -1733,7 +1750,7 @@ snapshots:
       '@shikijs/transformers': 2.5.0
       '@shikijs/types': 2.5.0
       '@types/markdown-it': 14.1.2
-      '@vitejs/plugin-vue': 5.2.4(vite@5.4.21(@types/node@25.3.0))(vue@3.5.29)
+      '@vitejs/plugin-vue': 5.2.4(vite@5.4.21(@types/node@25.5.0))(vue@3.5.31)
       '@vue/devtools-api': 7.7.9
       '@vue/shared': 3.5.29
       '@vueuse/core': 12.8.2
@@ -1742,10 +1759,10 @@ snapshots:
       mark.js: 8.11.1
       minisearch: 7.2.0
       shiki: 2.5.0
-      vite: 5.4.21(@types/node@25.3.0)
-      vue: 3.5.29
+      vite: 5.4.21(@types/node@25.5.0)
+      vue: 3.5.31
     optionalDependencies:
-      postcss: 8.5.6
+      postcss: 8.5.8
     transitivePeerDependencies:
       - '@algolia/client-search'
       - '@types/node'
@@ -1773,13 +1790,13 @@ snapshots:
       - typescript
       - universal-cookie
 
-  vue@3.5.29:
+  vue@3.5.31:
     dependencies:
-      '@vue/compiler-dom': 3.5.29
-      '@vue/compiler-sfc': 3.5.29
-      '@vue/runtime-dom': 3.5.29
-      '@vue/server-renderer': 3.5.29(vue@3.5.29)
-      '@vue/shared': 3.5.29
+      '@vue/compiler-dom': 3.5.31
+      '@vue/compiler-sfc': 3.5.31
+      '@vue/runtime-dom': 3.5.31
+      '@vue/server-renderer': 3.5.31(vue@3.5.31)
+      '@vue/shared': 3.5.31
 
   w3c-keyname@2.2.8: {}
 


### PR DESCRIPTION
- Replace polling loop (`setTimeout` every 100ms) with `yue:ready` event listener for WASM initialization
- Wire up dead `loadStub` to `s.onerror` so the compiler UI degrades gracefully when WASM fails to load
- Deduplicate CodeMirror theme and highlight style definitions using factory functions
- Fix CompilerModal dark mode (hardcoded `#ffffff` background -> `var(--vp-c-bg)`)
- Replace hardcoded button colors with existing CSS variables (`--vp-button-brand-*`)
- Remove redundant ternary expression
- Bump dependencies
